### PR TITLE
Fix escaping for args for python3

### DIFF
--- a/MySQLdb/cursors.py
+++ b/MySQLdb/cursors.py
@@ -158,11 +158,11 @@ class BaseCursor(object):
                 query = query.decode();
 
             if isinstance(args, dict):
-                query = query.format( **db.literal(args) )
+                query = query % db.literal(args)
             elif isinstance(args, tuple) or isinstance(args, list):
-                query = query.format( *db.literal(args) )
+                query = query % db.literal(args)
             else:
-                query = query.format( db.literal(args) )
+                query = query % db.literal(args)
 
         if isinstance(query, str):
             query = query.encode(charset);


### PR DESCRIPTION
Prior to this change, passing a dict or tuple of args to connection.execute did not work, the %s would be left in the query without the replacements being substituted in.
